### PR TITLE
Update competition test server to rc3

### DIFF
--- a/example-competition-server/README.md
+++ b/example-competition-server/README.md
@@ -54,6 +54,7 @@ would be the following:
 - `crs`: This stores information the competition server uses to access the CRS
 - `github.pat`: The server must download fuzz tooling and challenge repositories from GitHub, so you must add a GitHub personal access token with repository read access here in order for the server to work. This token
   must have the `repo` scope. You may use the same access token that you used for container registry, just as long as it has both the `repo` scope and the `read:packages` scope enabled.
+- `api_host_and_port`: This should be set to whatever host and port your CRS is using to send submissions to.
 
 ### `signoz/otel-collector-config.yaml`
 

--- a/example-competition-server/compose.yaml
+++ b/example-competition-server/compose.yaml
@@ -35,7 +35,7 @@ services:
       - shared-tmp:/tmp
 
   scantron:
-    image: ghcr.io/aixcc-finals/example-crs-architecture/competition-test-api:v1.1-rc2
+    image: ghcr.io/aixcc-finals/example-crs-architecture/competition-test-api:v1.1-rc3
     platform: linux/amd64
     privileged: true
     volumes:

--- a/example-competition-server/scantron.yaml
+++ b/example-competition-server/scantron.yaml
@@ -31,6 +31,7 @@ round_id: testing
 
 # Listen address outside the container
 listen_address: "[::]:1323"
+api_host_and_port: "localhost:1323"
 
 github:
   # github Personal Access token. This is used by the server to download the


### PR DESCRIPTION
v1.1-rc3 implements the `api_host_and_port` configuration field. This rc exists is to resolve an issue related to the /files endpoint, where the server served source repository tarballs based on the `listen_address` configuration field, rather than a separate field.